### PR TITLE
Support configurable NamingStrategy.ExampleName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support configurable `NamingStrategy.ExampleName`  ([#32](https://github.com/cucumber/cucumber-junit-xml-formatter/pull/32), M.P. Korstanje)
 
 ## [0.4.0] - 2024-04-05
 ### Changed

--- a/java/src/main/java/io/cucumber/junitxmlformatter/MessagesToJunitXmlWriter.java
+++ b/java/src/main/java/io/cucumber/junitxmlformatter/MessagesToJunitXmlWriter.java
@@ -1,6 +1,7 @@
 package io.cucumber.junitxmlformatter;
 
 import io.cucumber.messages.types.Envelope;
+import io.cucumber.query.NamingStrategy;
 
 import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
@@ -8,6 +9,8 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 
+import static io.cucumber.query.NamingStrategy.FeatureName.EXCLUDE;
+import static io.cucumber.query.NamingStrategy.Strategy.LONG;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -20,10 +23,23 @@ import static java.util.Objects.requireNonNull;
 public class MessagesToJunitXmlWriter implements AutoCloseable {
 
     private final OutputStreamWriter out;
-    private final XmlReportData data = new XmlReportData();
+    private final XmlReportData data;
     private boolean streamClosed = false;
 
     public MessagesToJunitXmlWriter(OutputStream out) {
+        this(NamingStrategy.ExampleName.NUMBER, out);
+    }
+
+    public MessagesToJunitXmlWriter(NamingStrategy.ExampleName exampleNameStrategy, OutputStream out) {
+        this(createNamingStrategy(requireNonNull(exampleNameStrategy)), out);
+    }
+
+    private static NamingStrategy createNamingStrategy(NamingStrategy.ExampleName exampleName) {
+        return NamingStrategy.strategy(LONG).featureName(EXCLUDE).exampleName(exampleName).build();
+    }
+
+    private MessagesToJunitXmlWriter(NamingStrategy namingStrategy, OutputStream out) {
+        this.data = new XmlReportData(namingStrategy);
         this.out = new OutputStreamWriter(
                 requireNonNull(out),
                 StandardCharsets.UTF_8

--- a/java/src/main/java/io/cucumber/junitxmlformatter/XmlReportData.java
+++ b/java/src/main/java/io/cucumber/junitxmlformatter/XmlReportData.java
@@ -22,8 +22,6 @@ import java.util.Map.Entry;
 import java.util.Optional;
 
 import static io.cucumber.messages.types.TestStepResultStatus.PASSED;
-import static io.cucumber.query.NamingStrategy.FeatureName.EXCLUDE;
-import static io.cucumber.query.NamingStrategy.Strategy.LONG;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.counting;
@@ -33,12 +31,13 @@ import static java.util.stream.Collectors.toList;
 class XmlReportData {
 
     private final Query query = new Query();
-    private final NamingStrategy namingStrategy = NamingStrategy
-            .strategy(LONG)
-            .featureName(EXCLUDE)
-            .build();
+    private final NamingStrategy namingStrategy;
 
     private static final long MILLIS_PER_SECOND = SECONDS.toMillis(1L);
+
+    public XmlReportData(NamingStrategy namingStrategy) {
+        this.namingStrategy = namingStrategy;
+    }
 
     void collect(Envelope envelope) {
         query.update(envelope);


### PR DESCRIPTION
### 🤔 What's changed?
Support configurable NamingStrategy.ExampleName

For example:

```java
public final class MyJUnitXmlFormatter implements ConcurrentEventListener {

    private final MessagesToJunitXmlWriter writer;

    public JUnitFormatter(OutputStream out) {
        this.writer = new MessagesToJunitXmlWriter(NamingStrategy.ExampleName.PICKLE, out);
    }

    @Override
    public void setEventPublisher(EventPublisher publisher) {
        publisher.registerHandlerFor(Envelope.class, this::write);
    }

    private void write(Envelope event) {
        try {
            writer.write(event);
        } catch (IOException e) {
            throw new IllegalStateException(e);
        }

        if (event.getTestRunFinished().isPresent()) {
            try {
                writer.close();
            } catch (IOException e) {
                throw new IllegalStateException(e);
            }
        }
    }

}
```

Note: Cucumber-JVM at present doesn't allow much configuration of plugins. To take advantage of this new option, the class above must be copied. And can be used in Cucumber-JVM with
`cucumber.plugin=com.example.MyJUnitXmlFormatter:target/report.xml`.

Fixes: #27

### 🏷️ What kind of change is this?
- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
