### PR TITLE
[JavaScript] Ensure query>=15 is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [JavaScript] Ensure query>=15 is used ([#143](https://github.com/cucumber/junit-xml-formatter/pull/143))
 
 ## [0.13.2] - 2026-02-25
 ### Fixed

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.13.2",
       "license": "MIT",
       "dependencies": {
-        "@cucumber/query": "^14.0.1 || ^15.0.0",
+        "@cucumber/query": "^15.0.1",
         "@teppeis/multimaps": "^3.0.0",
         "luxon": "^3.5.0",
         "xmlbuilder": "^15.1.1"
@@ -81,9 +81,9 @@
       }
     },
     "node_modules/@cucumber/query": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/query/-/query-15.0.0.tgz",
-      "integrity": "sha512-Vnc7Ap0nyzNrxo3ItwljkC8F8dsDKpacbrLpf136/3hd+yq0OMV64iZFW9owzrjFBYIGTCXK2PwoeWY2pApf2A==",
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/query/-/query-15.0.1.tgz",
+      "integrity": "sha512-FMfT3orJblRsOxvU2doECBvQmauizYlj+5JsM8atAKKPbnQTj7v2/OrnuykvQpfZNBf19DYbRq1e832vllRP/g==",
       "license": "MIT",
       "dependencies": {
         "@teppeis/multimaps": "3.0.0",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -21,7 +21,7 @@
     "prepublishOnly": "tsc --build tsconfig.build.json"
   },
   "dependencies": {
-    "@cucumber/query": "^14.0.1 || ^15.0.0",
+    "@cucumber/query": "^15.0.1",
     "@teppeis/multimaps": "^3.0.0",
     "luxon": "^3.5.0",
     "xmlbuilder": "^15.1.1"


### PR DESCRIPTION
### 🤔 What's changed?

Ensure `@cucumber/query` >= 15 is used.

### ⚡️ What's your motivation? 

https://github.com/cucumber/cucumber-js/issues/2786

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
