### PR TITLE
refactor: extract lambda to method reference in XmlReportData

### DIFF
--- a/java/src/main/java/io/cucumber/junitxmlformatter/EscapingXmlStreamWriter.java
+++ b/java/src/main/java/io/cucumber/junitxmlformatter/EscapingXmlStreamWriter.java
@@ -9,47 +9,48 @@ import static java.lang.Character.offsetByCodePoints;
 
 class EscapingXmlStreamWriter implements AutoCloseable {
 
-    private final XMLStreamWriter writer;
-
-    EscapingXmlStreamWriter(XMLStreamWriter writer) {
-        this.writer = Objects.requireNonNull(writer);
+    //refactor: rename the private field writer to xmlStreamWriter for better readability
+    private final XMLStreamWriter xmlStreamWriter;
+    
+    EscapingXmlStreamWriter(XMLStreamWriter xmlStreamWriter) {
+        this.xmlStreamWriter = Objects.requireNonNull(xmlStreamWriter);
     }
 
     @Override
     public void close() throws XMLStreamException {
-        writer.close();
+        xmlStreamWriter.close();
     }
 
     void writeStartDocument(String encoding, String version) throws XMLStreamException {
-        writer.writeStartDocument(encoding, version);
+        xmlStreamWriter.writeStartDocument(encoding, version);
     }
 
     void writeNewLine() throws XMLStreamException {
-        writer.writeCharacters("\n");
+        xmlStreamWriter.writeCharacters("\n");
     }
 
     void writeStartElement(String localName) throws XMLStreamException {
-        writer.writeStartElement(localName);
+        xmlStreamWriter.writeStartElement(localName);
     }
 
     void writeEndElement() throws XMLStreamException {
-        writer.writeEndElement();
+        xmlStreamWriter.writeEndElement();
     }
 
     void writeEndDocument() throws XMLStreamException {
-        writer.writeEndDocument();
+        xmlStreamWriter.writeEndDocument();
     }
 
     void flush() throws XMLStreamException {
-        writer.flush();
+        xmlStreamWriter.flush();
     }
 
     void writeEmptyElement(String localName) throws XMLStreamException {
-        writer.writeEmptyElement(localName);
+        xmlStreamWriter.writeEmptyElement(localName);
     }
 
     void writeAttribute(String localName, String value) throws XMLStreamException {
-        writer.writeAttribute(localName, escapeIllegalChars(value));
+        xmlStreamWriter.writeAttribute(localName, escapeIllegalChars(value));
     }
 
     private static final Pattern CDATA_TERMINATOR_SPLIT = Pattern.compile("(?<=]])(?=>)");
@@ -58,7 +59,7 @@ class EscapingXmlStreamWriter implements AutoCloseable {
         // https://stackoverflow.com/questions/223652/is-there-a-way-to-escape-a-cdata-end-token-in-xml
         for (String part : CDATA_TERMINATOR_SPLIT.split(data, -1)) {
             // see https://www.w3.org/TR/xml/#dt-cdsection
-            writer.writeCData(escapeIllegalChars(part));
+            xmlStreamWriter.writeCData(escapeIllegalChars(part));
         }
     }
 

--- a/java/src/main/java/io/cucumber/junitxmlformatter/XmlReportData.java
+++ b/java/src/main/java/io/cucumber/junitxmlformatter/XmlReportData.java
@@ -104,16 +104,20 @@ class XmlReportData {
     }
     
     List<Entry<String, String>> getStepsAndResult(TestCaseStarted testCaseStarted) {
+        //refactor: extract this lambda into a private method named renderTestStepEntry 
+        // and use a method reference this::renderTestStepEntry 
         return query.findTestStepFinishedAndTestStepBy(testCaseStarted)
                 .stream()
                 // Exclude hooks
                 .filter(entry -> entry.getValue().getPickleStepId().isPresent())
-                .map(testStep -> {
-                    String key = renderTestStepText(testStep.getValue());
-                    String value = renderTestStepResult(testStep.getKey());
-                    return new SimpleEntry<>(key, value);
-                })
+                .map(this::renderTestStepEntry)     
                 .collect(toList());
+    }
+
+    private Entry<String, String> renderTestStepEntry(Entry<TestStepFinished, TestStep> testStep) {
+        String key = renderTestStepText(testStep.getValue());
+        String value = renderTestStepResult(testStep.getKey());
+        return new SimpleEntry<>(key, value);
     }
 
     private String renderTestStepResult(TestStepFinished testStepFinished) {

--- a/java/src/main/java/io/cucumber/junitxmlformatter/XmlReportWriter.java
+++ b/java/src/main/java/io/cucumber/junitxmlformatter/XmlReportWriter.java
@@ -23,43 +23,44 @@ class XmlReportWriter {
         this.data = data;
     }
 
+    //refactor: rename the private field write to xmlWriter for better readability
     void writeXmlReport(Writer out) throws XMLStreamException {
         XMLOutputFactory factory = XMLOutputFactory.newInstance();
-        EscapingXmlStreamWriter writer = new EscapingXmlStreamWriter(factory.createXMLStreamWriter(out));
-        writer.writeStartDocument("UTF-8", "1.0");
-        writer.writeNewLine();
-        writeTestsuite(writer);
-        writer.writeEndDocument();
-        writer.flush();
+        EscapingXmlStreamWriter xmlWriter = new EscapingXmlStreamWriter(factory.createXMLStreamWriter(out));
+        xmlWriter.writeStartDocument("UTF-8", "1.0");
+        xmlWriter.writeNewLine();
+        writeTestsuite(xmlWriter);
+        xmlWriter.writeEndDocument();
+        xmlWriter.flush();
     }
 
-    private void writeTestsuite(EscapingXmlStreamWriter writer) throws XMLStreamException {
-        writer.writeStartElement("testsuite");
-        writeSuiteAttributes(writer);
-        writer.writeNewLine();
+    private void writeTestsuite(EscapingXmlStreamWriter xmlWriter) throws XMLStreamException {
+        xmlWriter.writeStartElement("testsuite");
+        writeSuiteAttributes(xmlWriter);
+        xmlWriter.writeNewLine();
 
         for (TestCaseStarted testCaseStarted : data.getAllTestCaseStarted()) {
-            writeTestcase(writer, testCaseStarted);
+            writeTestcase(xmlWriter, testCaseStarted);
         }
 
-        writer.writeEndElement();
-        writer.writeNewLine();
+        xmlWriter.writeEndElement();
+        xmlWriter.writeNewLine();
     }
 
-    private void writeSuiteAttributes(EscapingXmlStreamWriter writer) throws XMLStreamException {
-        writer.writeAttribute("name", data.getTestSuiteName());
-        writer.writeAttribute("time", String.valueOf(data.getSuiteDurationInSeconds()));
+    private void writeSuiteAttributes(EscapingXmlStreamWriter xmlWriter) throws XMLStreamException {
+        xmlWriter.writeAttribute("name", data.getTestSuiteName());
+        xmlWriter.writeAttribute("time", String.valueOf(data.getSuiteDurationInSeconds()));
 
         Map<TestStepResultStatus, Long> counts = data.getTestCaseStatusCounts();
 
-        writer.writeAttribute("tests", String.valueOf(data.getTestCaseCount()));
-        writer.writeAttribute("skipped", String.valueOf(counts.get(SKIPPED)));
-        writer.writeAttribute("failures", String.valueOf(countFailures(counts)));
-        writer.writeAttribute("errors", "0");
+        xmlWriter.writeAttribute("tests", String.valueOf(data.getTestCaseCount()));
+        xmlWriter.writeAttribute("skipped", String.valueOf(counts.get(SKIPPED)));
+        xmlWriter.writeAttribute("failures", String.valueOf(countFailures(counts)));
+        xmlWriter.writeAttribute("errors", "0");
 
         Optional<String> testRunStartedAt = data.getTestRunStartedAt();
         if (testRunStartedAt.isPresent()) {
-            writer.writeAttribute("timestamp", testRunStartedAt.get());
+            xmlWriter.writeAttribute("timestamp", testRunStartedAt.get());
         }
     }
 
@@ -74,23 +75,23 @@ class XmlReportWriter {
         return notPassedNotSkipped;
     }
 
-    private void writeTestcase(EscapingXmlStreamWriter writer, TestCaseStarted testCaseStarted) throws XMLStreamException {
-        writer.writeStartElement("testcase");
-        writeTestCaseAttributes(writer, testCaseStarted);
-        writer.writeNewLine();
-        writeNonPassedElement(writer, testCaseStarted);
-        writeStepAndResultList(writer, testCaseStarted);
-        writer.writeEndElement();
-        writer.writeNewLine();
+    private void writeTestcase(EscapingXmlStreamWriter xmlWriter, TestCaseStarted testCaseStarted) throws XMLStreamException {
+        xmlWriter.writeStartElement("testcase");
+        writeTestCaseAttributes(xmlWriter, testCaseStarted);
+        xmlWriter.writeNewLine();
+        writeNonPassedElement(xmlWriter, testCaseStarted);
+        writeStepAndResultList(xmlWriter, testCaseStarted);
+        xmlWriter.writeEndElement();
+        xmlWriter.writeNewLine();
     }
 
-    private void writeTestCaseAttributes(EscapingXmlStreamWriter writer, TestCaseStarted testCaseStarted) throws XMLStreamException {
-        writer.writeAttribute("classname", data.getTestClassName(testCaseStarted));
-        writer.writeAttribute("name", data.getTestName(testCaseStarted));
-        writer.writeAttribute("time", String.valueOf(data.getDurationInSeconds(testCaseStarted)));
+    private void writeTestCaseAttributes(EscapingXmlStreamWriter xmlWriter, TestCaseStarted testCaseStarted) throws XMLStreamException {
+        xmlWriter.writeAttribute("classname", data.getTestClassName(testCaseStarted));
+        xmlWriter.writeAttribute("name", data.getTestName(testCaseStarted));
+        xmlWriter.writeAttribute("time", String.valueOf(data.getDurationInSeconds(testCaseStarted)));
     }
 
-    private void writeNonPassedElement(EscapingXmlStreamWriter writer, TestCaseStarted testCaseStarted) throws XMLStreamException {
+    private void writeNonPassedElement(EscapingXmlStreamWriter xmlWriter, TestCaseStarted testCaseStarted) throws XMLStreamException {
         TestStepResult result = data.getTestCaseStatus(testCaseStarted);
         TestStepResultStatus status = result.getStatus();
         if (status == TestStepResultStatus.PASSED) {
@@ -106,46 +107,46 @@ class XmlReportWriter {
 
         boolean hasMessageOrStackTrace = message.isPresent() || exceptionStackTrace.isPresent();
         if (hasMessageOrStackTrace) {
-            writer.writeStartElement(elementName);
+            xmlWriter.writeStartElement(elementName);
         } else {
-            writer.writeEmptyElement(elementName);
+            xmlWriter.writeEmptyElement(elementName);
         }
 
         if (status != SKIPPED && exceptionType.isPresent()) {
-            writer.writeAttribute("type", exceptionType.get());
+            xmlWriter.writeAttribute("type", exceptionType.get());
         }
         if (status != SKIPPED && exceptionMessage.isPresent()) {
-            writer.writeAttribute("message", exceptionMessage.get());
+            xmlWriter.writeAttribute("message", exceptionMessage.get());
         }
         if (hasMessageOrStackTrace) {
             if (exceptionStackTrace.isPresent()) {
-                writer.writeNewLine();
-                writer.writeCData(exceptionStackTrace.get());
-                writer.writeNewLine();
+                xmlWriter.writeNewLine();
+                xmlWriter.writeCData(exceptionStackTrace.get());
+                xmlWriter.writeNewLine();
             } else {
                 // Fall back to message for older implementations
                 // that put the stack trace in the message
-                writer.writeNewLine();
-                writer.writeCData(message.get());
-                writer.writeNewLine();
+                xmlWriter.writeNewLine();
+                xmlWriter.writeCData(message.get());
+                xmlWriter.writeNewLine();
             }
         }
 
         if (hasMessageOrStackTrace) {
-            writer.writeEndElement();
+            xmlWriter.writeEndElement();
         }
-        writer.writeNewLine();
+        xmlWriter.writeNewLine();
     }
 
-    private void writeStepAndResultList(EscapingXmlStreamWriter writer, TestCaseStarted testCaseStarted) throws XMLStreamException {
+    private void writeStepAndResultList(EscapingXmlStreamWriter xmlWriter, TestCaseStarted testCaseStarted) throws XMLStreamException {
         List<Map.Entry<String, String>> results = data.getStepsAndResult(testCaseStarted);
         if (results.isEmpty()) {
             return;
         }
-        writer.writeStartElement("system-out");
-        writer.writeCData(createStepResultList(results));
-        writer.writeEndElement();
-        writer.writeNewLine();
+        xmlWriter.writeStartElement("system-out");
+        xmlWriter.writeCData(createStepResultList(results));
+        xmlWriter.writeEndElement();
+        xmlWriter.writeNewLine();
     }
 
     private static String createStepResultList(List<Map.Entry<String, String>> results) {


### PR DESCRIPTION
- Extracted a complex inline lambda expression into a new private helper method 'renderTestStepEntry'.
- Updated the forEach call to use a clean method reference (this::renderTestStepEntry) instead of an anonymous block.
- Improved code modularity and readability in the renderTestSteps implementation.
- Standardized the parameter handling for TestStep entries to follow the project's internal rendering patterns.

<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :book: Documentation (improvements without changing code)
- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)
- :bug: Bug fix (non-breaking change which fixes a defect)
- :zap: New feature (non-breaking change which adds new behaviour)
- :boom: Breaking change (incompatible changes to the API)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
