### PR TITLE
Switch to ESM

### DIFF
--- a/.github/workflows/test-javascript.yml
+++ b/.github/workflows/test-javascript.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        node-version: ["20.x", "22.x", "24.x"]
+        node-version: ["22.x", "24.x", "26.x"]
         include:
           - os: windows-latest
             node-version: "22.x"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- BREAKING CHANGE: [JavaScript] Switch to ESM ([#156](https://github.com/cucumber/junit-xml-formatter/pull/156))
 
 ## [0.13.3] - 2026-04-14
 ### Fixed

--- a/javascript/.mocharc.json
+++ b/javascript/.mocharc.json
@@ -1,5 +1,5 @@
 {
-  "require": "ts-node/register",
+  "node-option": ["loader=ts-node/esm"],
   "extension": ["ts"],
   "recursive": true
 }

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@cucumber/junit-xml-formatter",
   "version": "0.13.3",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -17,6 +18,7 @@
     "clean": "rm -rf dist",
     "fix": "biome check --fix --error-on-warnings",
     "lint": "biome check --error-on-warnings",
+    "postbuild": "node -e \"require('.')\"",
     "test": "mocha \"src/**/*.spec.ts\"",
     "prepublishOnly": "npm run build"
   },

--- a/javascript/src/JUnitXmlPrinter.ts
+++ b/javascript/src/JUnitXmlPrinter.ts
@@ -14,8 +14,8 @@ import {
 } from '@cucumber/query'
 import xmlbuilder from 'xmlbuilder'
 
-import { countStatuses, durationToSeconds, ensure, formatStep, formatTimestamp } from './helpers'
-import type { Options } from './types'
+import { countStatuses, durationToSeconds, ensure, formatStep, formatTimestamp } from './helpers.js'
+import type { Options } from './types.js'
 
 const DEFAULT_NAMING_STRATEGY = namingStrategy(
   NamingStrategyLength.LONG,

--- a/javascript/src/helpers.spec.ts
+++ b/javascript/src/helpers.spec.ts
@@ -2,7 +2,7 @@ import { type PickleStep, type Step, TestStepResultStatus } from '@cucumber/mess
 import { expect, use } from 'chai'
 import chaiAlmost from 'chai-almost'
 
-import { countStatuses, durationToSeconds, formatStep } from './helpers'
+import { countStatuses, durationToSeconds, formatStep } from './helpers.js'
 
 use(chaiAlmost())
 

--- a/javascript/src/index.ts
+++ b/javascript/src/index.ts
@@ -1,6 +1,6 @@
-import { plugin } from './plugin'
+import { plugin } from './plugin.js'
 
-export * from './JUnitXmlPrinter'
-export * from './types'
+export * from './JUnitXmlPrinter.js'
+export * from './types.js'
 
 export default plugin

--- a/javascript/src/plugin.spec.ts
+++ b/javascript/src/plugin.spec.ts
@@ -10,7 +10,7 @@ import { expect, use } from 'chai'
 import chaiXml from 'chai-xml'
 import { globbySync } from 'globby'
 
-import { plugin } from './plugin'
+import { plugin } from './plugin.js'
 
 use(chaiXml)
 
@@ -18,7 +18,7 @@ describe('Acceptance Tests', async function () {
   this.timeout(10_000)
 
   const ndjsonFiles = globbySync(`*.ndjson`, {
-    cwd: path.join(__dirname, '../../testdata/src'),
+    cwd: path.join(import.meta.dirname, '../../testdata/src'),
     absolute: true,
   })
 

--- a/javascript/src/plugin.ts
+++ b/javascript/src/plugin.ts
@@ -1,7 +1,7 @@
 import type { Envelope } from '@cucumber/messages'
 
-import { JUnitXmlPrinter } from './JUnitXmlPrinter'
-import type { Options } from './types'
+import { JUnitXmlPrinter } from './JUnitXmlPrinter.js'
+import type { Options } from './types.js'
 
 export const plugin = {
   type: 'formatter',


### PR DESCRIPTION
### 🤔 What's changed?

Switch this JavaScript package from CommonJS output to ESM.

Also change the Node.js versions used to test in CI, to match today's Current + LTS landscape.

### ⚡️ What's your motivation? 

Part of https://github.com/cucumber/common/issues/2232.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)
- :boom: Breaking change (incompatible changes to the API)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
